### PR TITLE
impr: OP-2766 support NPM 8.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "tools-profile-management",
 			"version": "1.0.2",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
@@ -9554,6 +9555,20 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"node_modules/typescript": {
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
 		"node_modules/union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -11197,7 +11212,8 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
 			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "6.2.0",
@@ -14296,7 +14312,8 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "25.2.6",
@@ -17512,6 +17529,13 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"typescript": {
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+			"dev": true,
+			"peer": true
+		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -17863,7 +17887,8 @@
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
 			"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",


### PR DESCRIPTION
### Issue Link:

OP-2766

### What does it do?

This PR updates the package lock file, as `npm ci` did not work on this repo with npm 8.x

#### Checklist

- [x] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] I will merge without squashing: All commits conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] README update

---

#### Notes to reviewers

This PR was created with the `mass_repo_update` script.